### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [SilverBullet](https://silverbullet.md/) chart for Kubernetes. [SilverBullet](
 # TL;DR;
 
 ```console
-helm repo add silverbullet https://bnason.github.io/silverbullet-helm
+helm repo add silverbullet https://bnason.github.io/silverbullet-chart
 helm --namespace=silverbullet --create-namespace install silverbullet silverbullet/silverbullet
 ```
 


### PR DESCRIPTION
Noticed this didn't match with the repositories path.

```
❯ helm repo add silverbullet https://bnason.github.io/silverbullet-helm
Error: looks like "https://bnason.github.io/silverbullet-helm" is not a valid chart repository or cannot be reached: failed to fetch https://bnason.github.io/silverbullet-helm/index.yaml : 404 Not Found
```

The updated path works:
```
❯ helm repo add silverbullet https://bnason.github.io/silverbullet-chart
"silverbullet" has been added to your repositories
```