### PR TITLE
Update secret.yaml

### DIFF
--- a/charts/silverbullet/templates/secret.yaml
+++ b/charts/silverbullet/templates/secret.yaml
@@ -16,10 +16,6 @@ data:
 {{- if .Values.runMode.readOnly }}
   SB_READ_ONLY: {{ ternary "true" "false" .Values.runMode.readOnly | b64enc }}
 {{- end -}}
-{{- if .Values.admin.username }}
-  {{- $sbUser := print .Values.admin.username ":" .Values.admin.password }}
-  SB_USER: {{ $sbUser | b64enc }}
-{{- end -}}
 {{- if .Values.git.name }}
   GIT_NAME: {{ .Values.git.name | b64enc }}
 {{- end -}}


### PR DESCRIPTION
Causes a secret to be generated that has `SB_USER` set twice with the same value:
```
# Source: silverbullet/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: silverbullet
  labels:
    helm.sh/chart: silverbullet-0.4.0
    app.kubernetes.io/name: silverbullet
    app.kubernetes.io/instance: silverbullet
    app.kubernetes.io/version: "0.7.7"
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
  SB_USER: <redacted base64>
  SB_USER: <same value as above>
```